### PR TITLE
fix Home component render in react-router Switch

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -10,9 +10,11 @@ function App() {
     <div id="body">
     <Header />
     <Switch>
-      <Route exact path={'/'} compnent={Home} />
-      <Route path={'./about'} component={About} />
-      <Route path={'./portfolio'} component={Portfolio} />
+      <Route exact path={'/'}>
+        <Home />
+      </Route>
+      <Route path={'/about'} component={About} />
+      <Route path={'/portfolio'} component={Portfolio} />
     </Switch>
     </div>
   );


### PR DESCRIPTION
@joshuajakab 
Fix to show how a `<Switch>` component needs a child to render when the path is exact and the page is the initial load page for the App.js, i.e. the `/` route.